### PR TITLE
Darstellungsfehler behoben

### DIFF
--- a/system/modules/language-editor/templates/be_translation_search.html5
+++ b/system/modules/language-editor/templates/be_translation_search.html5
@@ -73,8 +73,8 @@
 						<label for="ctrl_translation"><?php echo $GLOBALS['TL_LANG']['tl_translation']['langgroup'][0]; ?></label>
 					</h3>
 					<select id="ctrl_translation" name="translation">
-						<option value=""></option>
-						<?php var_dump($this->translations); foreach ($this->translations as $translation): ?>
+                        			<option value="">-</option>
+                        			<?php foreach ($this->translations as $translation): ?>
 						<option value="<?php echo $translation; ?>"<?php if ($_SESSION['tl_translation_search_translation'] == $translation): ?> selected="selected"<?php endif; ?>><?php echo $translation; ?></option>
 						<?php endforeach; ?>
 					</select>


### PR DESCRIPTION
Im Quelltext wurde das komplette Array ausgegeben. Das leere Options-Element hat ja seine Berechtigung um alle Gruppen zu durchsuchen. Das leere Element sollte auch noch einen Optionswert haben (nicht value) damit das Feld überhaupt angezeigt wird. Im FF hab ich ohne Wert nur nen grauen Balken.
PS: Der Text im Commit ist falsch was das Option-Element angeht, dass es außerhalb liegt. Das war vorher schon der Fall. Hab ich aber erst gesehen als der Text gespeichert war. :D
